### PR TITLE
Remove the declspec and genspec as they are not necessary.

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -27,8 +27,7 @@ task :compile do
         FileUtils.cp("bloom.h", "include", verbose: true)
         
         if Gem.win_platform?
-            system("gendef bloom.dll", exception: true)
-            FileUtils.cp(["bloom.d", "bloom.def", "bloom.dll", "bloom.dll.exp", "bloom.dll.lib", "bloom.pdb"], "lib", verbose: true)
+            FileUtils.cp(["bloom.d", "bloom.dll", "bloom.dll.exp", "bloom.dll.lib", "bloom.pdb"], "lib", verbose: true)
         else
             Dir.glob("libbloom.*").each do |filename|
                 destination = File.join("lib", filename)

--- a/build.rs
+++ b/build.rs
@@ -3,18 +3,6 @@ extern crate cbindgen;
 use std::env;
 use std::path::PathBuf;
 
-#[cfg(target_os = "windows")]
-fn configuration() -> cbindgen::Config {
-    let mut config: cbindgen::Config = Default::default();
-    config.function.prefix = Some("__declspec(dllexport)".to_string());
-    config
-}
-
-#[cfg(any(target_os = "linux", target_os = "macos"))]
-fn configuration() -> cbindgen::Config {
-    Default::default()
-}
-
 fn main() {
     let crate_dir = env::var("CARGO_MANIFEST_DIR").expect("Unable to read manifest directory.");
     let profile = env::var("PROFILE").expect("Unable to target profile.");
@@ -24,7 +12,7 @@ fn main() {
         .join(profile)
         .join("bloom.h");
 
-    let mut config: cbindgen::Config = configuration();
+    let mut config: cbindgen::Config = Default::default();
     config.language = cbindgen::Language::C;
     config.pragma_once = true;
 


### PR DESCRIPTION
Only the ruby path dll variable is required, so trim down the example to the bare minimum.