### PR TITLE
Implement a bloom filter API using the FFI gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,5 @@
 source "https://rubygems.org"
 
-gem 'rake', '13.0.3'
-gem 'rspec', '3.10'
+gem "rake", "13.0.3"
+gem "rspec", "3.10"
+gem "ffi", "1.15.3"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,18 @@ irb(main):001:0> Bloom::BloomFilter::new(42)
 => #<Bloom::BloomFilter:0x00007fc7a70b0970>
 ```
 
+# Benchmark
+The benchmarks can be run via `rake bench`.
+
+```
+$ rake bench
+                  user     system      total        real
+Pure Ruby         4.204919   0.018345   4.223264 (  4.241795)
+Rust via C-API    2.595431   0.013169   2.608600 (  2.620140)
+Rust via FFI gem  2.935205   0.009907   2.945112 (  2.956811)
+
+```
+
 # Resources
 * [Extending Ruby with C-extensions](https://ruby-doc.com/docs/ProgrammingRuby/html/ext_ruby.html)
 * [bindgen User Guide](https://rust-lang.github.io/rust-bindgen/introduction.html)

--- a/Rakefile
+++ b/Rakefile
@@ -52,7 +52,7 @@ end
 task :console => [:compile] do
     prepare_environment
 
-    exec("irb -I#{target_dir} -rbloom_filter")
+    exec("irb -I#{target_dir} -Ilib -rbloom_filter -rbloom_ffi -rbloom_ruby")
 end
 
 task :bench do

--- a/Rakefile
+++ b/Rakefile
@@ -4,8 +4,17 @@ def target_dir
     File.join(__dir__, "target", "debug")
 end
 
+def prepare_environment
+    if Gem.win_platform?
+        ENV["RUBY_DLL_PATH"] = target_dir
+    else
+        # Used by ffi gem
+        ENV["LD_LIBRARY_PATH"] = target_dir
+    end
+end
+
 RSpec::Core::RakeTask.new(:test) do |t|
-    ENV["RUBY_DLL_PATH"] = target_dir if Gem.win_platform?
+    prepare_environment
     t.rspec_opts = ["-I#{target_dir}"]
 end
 
@@ -41,17 +50,17 @@ task :compile do
 end
 
 task :console => [:compile] do
-    ENV["RUBY_DLL_PATH"] = target_dir if Gem.win_platform?
+    prepare_environment
 
     exec("irb -I#{target_dir} -rbloom_filter")
 end
 
 task :bench do
-    ENV["RUBY_DLL_PATH"] = target_dir if Gem.win_platform?
+    prepare_environment
 
     file_path = File.join("lib", "bloom_bench.rb")
 
-    exec("ruby -I#{target_dir} -Ilib -rbloom_filter -rbenchmark #{file_path}")
+    exec("ruby -I#{target_dir} -Ilib -rbenchmark #{file_path}")
 end
 
 task :clean do

--- a/extension/bloom_filter.c
+++ b/extension/bloom_filter.c
@@ -3,7 +3,7 @@
 #include <bloom.h>
 
 static void bloom_filter_free(void *p) {
-    BloomFilterDrop(p);
+    bloom_drop(p);
 }
 
 static VALUE bloom_filter_initialize(VALUE self)
@@ -14,7 +14,7 @@ static VALUE bloom_filter_initialize(VALUE self)
 VALUE bloom_filter_new(VALUE class, VALUE capacity) {
     Check_Type(capacity, T_FIXNUM);
 
-    BloomFilter *bloom_filter = BloomFilterNew(NUM2SIZET(capacity));
+    BloomFilter *bloom_filter = bloom_new(NUM2SIZET(capacity));
 
     VALUE tdata = Data_Wrap_Struct(class, 0, bloom_filter_free, bloom_filter);
     VALUE argv[0];
@@ -30,7 +30,7 @@ static VALUE bloom_filter_capacity(VALUE self)
 
     Data_Get_Struct(self, BloomFilter, ptr);
 
-    unsigned long capacity = BloomFilterCapacity(ptr);
+    unsigned long capacity = bloom_capacity(ptr);
 
     return SIZET2NUM(capacity);
 }
@@ -43,7 +43,7 @@ static VALUE bloom_filter_insert(VALUE self, VALUE value)
 
     Data_Get_Struct(self, BloomFilter, ptr);
 
-    bool already_contains = BloomFilterInsert(ptr, RSTRING_PTR(value));
+    bool already_contains = bloom_insert(ptr, RSTRING_PTR(value));
 
     return already_contains ? Qtrue : Qfalse;
 }
@@ -56,7 +56,7 @@ static VALUE bloom_filter_contains(VALUE self, VALUE value)
 
     Data_Get_Struct(self, BloomFilter, ptr);
 
-    bool contains = BloomFilterContains(ptr, RSTRING_PTR(value));
+    bool contains = bloom_contains(ptr, RSTRING_PTR(value));
 
     return contains ? Qtrue : Qfalse;
 }

--- a/extension/extconf.rb
+++ b/extension/extconf.rb
@@ -1,6 +1,6 @@
 require "mkmf"
 
 dir_config("bloom")
-have_library("bloom", "BloomFilterNew")
+have_library("bloom", "bloom_new")
 have_header("bloom.h")
 create_makefile("bloom_filter")

--- a/lib/bloom_bench.rb
+++ b/lib/bloom_bench.rb
@@ -1,36 +1,8 @@
-require 'set'
-require 'openssl'
+require "bloom_ruby"
+require "bloom_filter"
+require "bloom_ffi"
 
 module BloomBench
-  class BloomFilter
-    def initialize(capacity)
-      @digest = 'SHA512'
-      @markers = Array.new(capacity, false)
-    end
-
-    def capacity
-      @markers.size
-    end
-
-    def add(value)
-      contained = true
-
-      digest = OpenSSL::Digest.new(@digest).digest(value.to_s)
-      digest.unpack("J*").each do |i|
-        index = i % self.capacity
-        contained &&= @markers[index]
-        @markers[index] = true
-      end
-
-      contained
-    end
-
-    def include?(value)
-      digest = OpenSSL::Digest.new(@digest).digest(value.to_s)
-      digest.unpack("J*").all? { |i| @markers[index = i % self.capacity] }
-    end
-  end
-
   def self.exercise(items=1_000, &block)
     bloom_filter = block.call(42)
 
@@ -46,11 +18,11 @@ module BloomBench
   end
 end
 
-n = 1_000
+n = 1
 Benchmark.bm do |x|
   x.report("Pure Ruby") do
     n.times do
-      BloomBench.exercise { |capacity| BloomBench::BloomFilter.new(capacity) }
+      BloomBench.exercise { |capacity| BloomRuby::BloomFilter.new(capacity) }
     end
   end
 
@@ -62,7 +34,7 @@ Benchmark.bm do |x|
 
   x.report("Rust via FFI gem") do
     n.times do
-      #TODO
+      BloomBench.exercise { |capacity| BloomFFI::BloomFilter.new(capacity) }
     end
   end
 end

--- a/lib/bloom_bench.rb
+++ b/lib/bloom_bench.rb
@@ -18,7 +18,7 @@ module BloomBench
   end
 end
 
-n = 1
+n = 1_000
 Benchmark.bm do |x|
   x.report("Pure Ruby") do
     n.times do

--- a/lib/bloom_ffi.rb
+++ b/lib/bloom_ffi.rb
@@ -1,0 +1,24 @@
+require "ffi"
+
+module BloomFFI
+
+  module Library
+    extend FFI::Library
+    ffi_lib "bloom"
+
+    attach_function :BloomFilterDrop, [:pointer, :size_t], :pointer # returns fresh memory
+    attach_function :bloom_filter_initialize, [ :pointer ], :void             # frees memory
+    attach_function :bloom_filter_new, [ :pointer ], :void             # frees memory
+    attach_function :bloom_filter_capacity, [ :pointer ], :void             # frees memory
+    attach_function :bloom_filter_initialize, [ :pointer ], :void             # frees memory
+    attach_function :bloom_filter_initialize, [ :pointer ], :void             # frees memory
+
+  end
+
+  class AutoPointer < ::FFI::AutoPointer
+    # This method will be called by FFI::AutoPointer::DefaultReleaser.
+    def self.release(ptr)
+      Library.bloom_filter_free(ptr)
+    end
+  end
+end

--- a/lib/bloom_ruby.rb
+++ b/lib/bloom_ruby.rb
@@ -1,0 +1,37 @@
+require "openssl"
+
+module BloomRuby
+  class BloomFilter
+    def initialize(capacity)
+      @digest = "SHA512"
+      @markers = Array.new(capacity, false)
+    end
+
+    def capacity
+      @markers.size
+    end
+
+    def add(value)
+      contained = true
+
+      indices_of(value).each do |i|
+        index = i % self.capacity
+        contained &&= @markers[index]
+        @markers[index] = true
+      end
+
+      contained
+    end
+
+    def include?(value)
+      indices_of(value).all? { |i| @markers[index = i % self.capacity] }
+    end
+
+    private
+
+    def indices_of(value)
+      digest = OpenSSL::Digest.new(@digest).digest(value.to_s)
+      digest.unpack("J*")
+    end
+  end
+end

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,19 +6,19 @@ use libc::{c_char, size_t};
 use std::ffi::CStr;
 
 #[no_mangle]
-pub unsafe extern "C" fn BloomFilterNew(capacity: size_t) -> *mut BloomFilter {
+pub unsafe extern "C" fn bloom_new(capacity: size_t) -> *mut BloomFilter {
     Box::into_raw(Box::new(BloomFilter::new(capacity)))
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn BloomFilterDrop(bloom_filter: *mut BloomFilter) {
+pub unsafe extern "C" fn bloom_drop(bloom_filter: *mut BloomFilter) {
     if !bloom_filter.is_null() {
         Box::from_raw(bloom_filter);
     }
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn BloomFilterCapacity(bloom_filter: Option<&BloomFilter>) -> size_t {
+pub unsafe extern "C" fn bloom_capacity(bloom_filter: Option<&BloomFilter>) -> size_t {
     match bloom_filter {
         Some(bloom_filter) => bloom_filter.capacity(),
         None => 0,
@@ -26,7 +26,7 @@ pub unsafe extern "C" fn BloomFilterCapacity(bloom_filter: Option<&BloomFilter>)
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn BloomFilterInsert(
+pub unsafe extern "C" fn bloom_insert(
     bloom_filter: Option<&mut BloomFilter>,
     value: *const c_char,
 ) -> bool {
@@ -43,7 +43,7 @@ pub unsafe extern "C" fn BloomFilterInsert(
 }
 
 #[no_mangle]
-pub unsafe extern "C" fn BloomFilterContains(
+pub unsafe extern "C" fn bloom_contains(
     bloom_filter: Option<&BloomFilter>,
     value: *const c_char,
 ) -> bool {


### PR DESCRIPTION
Implement a bloom filter API using the FFI gem. Renames the Rust API to follow C-naming conventions.

Closing #12 