### PR TITLE
Re-enable FFI tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,6 +52,3 @@ jobs:
         run: bundle exec rake compile
       - name: Test Extension
         run: bundle exec rake test
-        env:
-          RUBY_DLL_PATH: ${{ env.GITHUB_WORKSPACE }}/target/debug
-          LD_LIBRARY_PATH: ${{ env.GITHUB_WORKSPACE }}/target/debug

--- a/Rakefile
+++ b/Rakefile
@@ -10,11 +10,12 @@ def prepare_environment
     else
         # Used by ffi gem
         ENV["LD_LIBRARY_PATH"] = target_dir
+        ENV["DYLD_LIBRARY_PATH"] = target_dir
+        ENV["DYLD_FALLBACK_LIBRARY_PATH"] = target_dir
     end
 end
 
 RSpec::Core::RakeTask.new(:test) do |t|
-    prepare_environment
     t.rspec_opts = ["-I#{target_dir} -Ilib"]
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -16,6 +16,7 @@ def prepare_environment
 end
 
 RSpec::Core::RakeTask.new(:test) do |t|
+    prepare_environment
     t.rspec_opts = ["-I#{target_dir} -Ilib"]
 end
 

--- a/lib/bloom_ffi.rb
+++ b/lib/bloom_ffi.rb
@@ -3,7 +3,9 @@ require "ffi"
 module BloomFFI
   extend FFI::Library
 
-  ffi_lib "bloom"
+  LIBRARY_NAME = "bloom"
+
+  ffi_lib [LIBRARY_NAME] + $LOAD_PATH.map {|p| File.join(p, FFI::map_library_name(LIBRARY_NAME)) }
 
   class BloomFilterPointer < ::FFI::AutoPointer
     def self.release(ptr)

--- a/spec/bloom_filter_spec.rb
+++ b/spec/bloom_filter_spec.rb
@@ -1,5 +1,8 @@
+puts("LD_LIBRARY_PATH=#{ENV["LD_LIBRARY_PATH"]}")
+
 require 'bloom_filter'
 require 'bloom_ruby'
+require 'bloom_ffi'
 
 RSpec.shared_examples "is a bloom filter" do
   it "#new" do
@@ -64,5 +67,13 @@ RSpec.describe BloomRuby::BloomFilter do
 end
 
 RSpec.describe BloomRuby::AtomicBloomFilter do
+  include_examples "is a bloom filter"
+end
+
+RSpec.describe BloomFFI::BloomFilter do
+  include_examples "is a bloom filter"
+end
+
+RSpec.describe BloomFFI::AtomicBloomFilter do
   include_examples "is a bloom filter"
 end


### PR DESCRIPTION
Re-enable FFI tests with a work-around to look for the lib in the load path if dlopen can't find it through normal means.